### PR TITLE
Update geth to 1.8.0

### DIFF
--- a/lib/GethBin.ts
+++ b/lib/GethBin.ts
@@ -8,8 +8,8 @@ import { unlink } from 'fs';
 const defaultTarget = path.join(__dirname, 'bin');
 
 const repo = 'https://gethstore.blob.core.windows.net/builds/';
-const gethVersion = '1.7.3';
-const gethCommit = '4bb3c89d';
+const gethVersion = '1.8.0';
+const gethCommit = '5f540757';
 // const baseUrl = url.resolve(repo, gethVersion);
 
 const source = {


### PR DESCRIPTION
The iceberg is here!
It would be cool to have it, light sync is fixed in this release.

p.s.
Can I ask also where I could look for if I wanted to connect akasha directly to my running geth and ipfs daemons? You think we could also connect to public gateways?